### PR TITLE
Use system proxy with http client and slf4j-simple to activate logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,12 @@
             <version>2.20.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+
 
     </dependencies>
 </project>

--- a/src/main/java/com/salesforce/commerce/intelligence/jdbc/client/CIPAvaticaHttpClient.java
+++ b/src/main/java/com/salesforce/commerce/intelligence/jdbc/client/CIPAvaticaHttpClient.java
@@ -124,7 +124,10 @@ public class CIPAvaticaHttpClient
     protected void initializeClient(PoolingHttpClientConnectionManager pool, ConnectionConfig config) {
         RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
         RequestConfig requestConfig = requestConfigBuilder.setConnectTimeout(config.getHttpConnectionTimeout(), TimeUnit.MILLISECONDS).setResponseTimeout( config.getHttpResponseTimeout(), TimeUnit.MILLISECONDS ).build();
-        HttpClientBuilder httpClientBuilder = HttpClients.custom().setConnectionManager(pool).setDefaultRequestConfig(requestConfig);
+        HttpClientBuilder httpClientBuilder = HttpClients.custom()
+                .useSystemProperties()
+                .setConnectionManager(pool)
+                .setDefaultRequestConfig(requestConfig);
         this.context = HttpClientContext.create();
         this.client = httpClientBuilder.build();
     }

--- a/src/main/java/com/salesforce/commerce/intelligence/jdbc/client/util/LoggingManager.java
+++ b/src/main/java/com/salesforce/commerce/intelligence/jdbc/client/util/LoggingManager.java
@@ -30,6 +30,11 @@ public class LoggingManager {
             // Enable all logging for the two classes
             Configurator.setLevel(CIPDriver.class.getName(), Level.ALL);
             Configurator.setLevel(CIPAvaticaHttpClient.class.getName(), Level.ALL);
+
+            Configurator.setLevel("org.apache.hc.client5.http.impl.classic", Level.ALL);
+            System.setProperty("org.slf4j.simpleLogger.log.org.apache.hc", "debug");
+            System.setProperty("org.slf4j.simpleLogger.log.org.apache.http", "debug");
+
             classCIPDriverLogger.debug("Logging enabled for CIPDriver.");
             classCIPAvaticaHttpClientLogger.debug("Logging enabled for CIPAvaticaHttpClient.");
             break;


### PR DESCRIPTION
When using the driver behind a proxy, old versions of HTTP client do not honor system properties by default.  
Also, avatica has a copy of an old version of "org.slf4j". This causes SLF4J to use NOP logger which will cause http logs to no be logged when needed